### PR TITLE
Add support for CunningFellow's 5 clock per pixel RLE video mode

### DIFF
--- a/cu_types.h
+++ b/cu_types.h
@@ -119,6 +119,8 @@ typedef struct{
  boole spm_prge;      /* SPM erasing or programming in progress */
  auint spm_mode;      /* SPM selected mode for the next SPM instruction */
  auint spm_end;       /* SPM enable end cycle */
+ boole usr0_tran;     /* USART0 transfer in progress */
+ auint usr0_end;      /* USART0 transfer end cycle */
 }cu_state_cpu_t;
 
 


### PR DESCRIPTION
All it does is trigger an interrupt 1304 cycles after a write to UDR0.
This is only the correct value for 1-7-N with UBRR=9. It is also only
correct with UDR and UBRR being written in consecutive instructions.

http://uzebox.org/forums/viewtopic.php?f=9&t=2386&start=170#p27772